### PR TITLE
Omit author_email if @ not found in authors

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -87,6 +87,12 @@ impl Metadata21 {
 
         let extra_metadata = cargo_toml.remaining_core_metadata();
 
+        let author_email = if authors.contains('@') {
+            Some(authors.clone())
+        } else {
+            None
+        };
+
         Ok(Metadata21 {
             metadata_version: "2.1".to_owned(),
 
@@ -104,8 +110,8 @@ impl Metadata21 {
             home_page: cargo_toml.package.homepage.clone(),
             download_url: None,
             // Cargo.toml has no distinction between author and author email
-            author: Some(authors.to_owned()),
-            author_email: Some(authors.to_owned()),
+            author: Some(authors),
+            author_email,
             license: cargo_toml.package.license.clone(),
 
             // Values provided through `[project.metadata.maturin]`


### PR DESCRIPTION
Following from: https://github.com/PyO3/maturin/issues/289 - Stop passing author.email to python

Fixes deploying to PyPI when an email address is not provided. 

This master branch also needs to be updated due the requirement:
```
File: anki/rspy/requirements.txt
1: # fixme: when maturin fixes 32 bit support, switch back to pypi
2: git+https://github.com/dae/maturin#egg=maturin; sys_platform == "linux" and platform_machine != "x86_64"
3: maturin; sys_platform != "linux" or platform_machine == "x86_64"
```

As of today, the new release `0.80.0` of `maturin` was released, within this fix, and it will be automatically used on the next installation because there is no restriction on the maturin requirement version.